### PR TITLE
Use forward slash in path

### DIFF
--- a/export_seanim.py
+++ b/export_seanim.py
@@ -244,7 +244,7 @@ def save(self, context):
 
     prefix = self.prefix  # os.path.basename(self.filepath)
     suffix = self.suffix
-    path = os.path.dirname(self.filepath) + "\\"
+    path = os.path.dirname(self.filepath) + "/"
 
     # Gets automatically updated per-action if self.use_actions is true,
     # otherwise it stays the same

--- a/import_seanim.py
+++ b/import_seanim.py
@@ -73,7 +73,7 @@ def load(self, context, filepath=""):
     if ob.type != 'ARMATURE':
         return "An armature must be selected!"
 
-    path = os.path.dirname(filepath) + "\\"
+    path = os.path.dirname(filepath) + "/"
 
     try:
         ob.animation_data.action


### PR DESCRIPTION
Otherwise it cannot import or export properly on Unix-like OSes