### PR TITLE
replace deprecated time.clock() with time.process_time()

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -46,12 +46,12 @@ class ImportSEAnim(bpy.types.Operator, ImportHelper):
     def execute(self, context):
         # print("Selected: " + context.active_object.name)
         from . import import_seanim
-        start_time = time.clock()
+        start_time = time.process_time()
         result = import_seanim.load(
             self, context, **self.as_keywords(ignore=("filter_glob", "files")))
         if not result:
             self.report({'INFO'}, "Import finished in %.4f sec." %
-                        (time.clock() - start_time))
+                        (time.process_time() - start_time))
             return {'FINISHED'}
         else:
             self.report({'ERROR'}, result)
@@ -160,11 +160,11 @@ class ExportSEAnim(bpy.types.Operator, ExportHelper):
     def execute(self, context):
         # print("Selected: " + context.active_object.name)
         from . import export_seanim
-        start_time = time.clock()
+        start_time = time.process_time()
         result = export_seanim.save(self, context)
         if not result:
             self.report({'INFO'}, "Export finished in %.4f sec." %
-                        (time.clock() - start_time))
+                        (time.process_time() - start_time))
             return {'FINISHED'}
         else:
             self.report({'ERROR'}, result)


### PR DESCRIPTION
time.clock() is stated to be deprecated: https://docs.python.org/3.3/library/time.html#time.clock

On my system python and blender installation it's already absent. I've replaced it with time.process_time() function as it was advised.